### PR TITLE
Type in the file.  Causes site to not work at all for AOIs

### DIFF
--- a/geoq/core/static/core/js/aoi_feature_edit.js
+++ b/geoq/core/static/core/js/aoi_feature_edit.js
@@ -14,7 +14,7 @@ aoi_feature_edit.all_markers = [];
 aoi_feature_edit.available_icons = [];
 aoi_feature_edit.MapMarker = null;
 
-});
+//});
 
 aoi_feature_edit.init = function () {
     aoi_feature_edit.drawcontrol = null;


### PR DESCRIPTION
Errors on the AOI edit page.  Extra characters you do not need.
